### PR TITLE
Refactor prediction market state management

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { SocketProvider } from './contexts/SocketContext';
 import { AuthProvider } from './contexts/AuthContext';
 import { ParlayProvider } from './contexts/ParlayContext';
+import { PredictionMarketProvider } from './contexts/PredictionMarketContext';
 import AppRoutes from './routes/AppRoutes';
 import MainLayout from './components/MainLayout';
 import { ThemeProvider } from './contexts/ThemeContext';
@@ -14,11 +15,13 @@ function App() {
         <ThemeProvider>
           <ChatProvider>
             <BrowserRouter>
-              <ParlayProvider>
-                <MainLayout>
-                  <AppRoutes />
-                </MainLayout>
-              </ParlayProvider>
+              <PredictionMarketProvider>
+                <ParlayProvider>
+                  <MainLayout>
+                    <AppRoutes />
+                  </MainLayout>
+                </ParlayProvider>
+              </PredictionMarketProvider>
             </BrowserRouter>
           </ChatProvider>
         </ThemeProvider>

--- a/apps/client/src/components/BetForm.tsx
+++ b/apps/client/src/components/BetForm.tsx
@@ -1,6 +1,6 @@
 // apps/client/src/components/BetForm.tsx
 import { useState } from 'react';
-import { useBetting } from '../hooks/useBetting';
+import { usePredictionMarket } from '../contexts/PredictionMarketContext';
 import { useAuth } from '../contexts/AuthContext';
 import type { PublicPredictionOption, PublicBet, BetWithUser } from '@ems/types';
 
@@ -12,7 +12,8 @@ interface BetFormProps {
 
 export default function BetForm({ prediction, addOptimisticBet, onPlaced }: BetFormProps) {
   const { options } = prediction;
-  const { placeBet, loading: placing, error } = useBetting();
+  const { placeBet, bettingLoading: placing, bettingError: error } =
+    usePredictionMarket();
   const { user } = useAuth();
   const balance = user?.muskBucks ?? 0;
 

--- a/apps/client/src/components/ParlayModal.tsx
+++ b/apps/client/src/components/ParlayModal.tsx
@@ -1,8 +1,7 @@
 // apps/client/src/components/ParlayModal.tsx
 import { useEffect } from 'react';
 import { useParlay } from '../contexts/ParlayContext';
-import { usePredictions } from '../hooks/usePredictions';
-import { useBetting } from '../hooks/useBetting';
+import { usePredictionMarket } from '../contexts/PredictionMarketContext';
 import type { PlaceParlayPayload } from '../api/betting';
 import type { PublicPredictionOption } from '@ems/types';
 
@@ -13,8 +12,13 @@ interface ParlayModalProps {
 
 export default function ParlayModal({ isOpen, onClose }: ParlayModalProps) {
   const { state, dispatch } = useParlay();
-  const { predictions } = usePredictions();
-  const { placeParlay, latestParlay, loading: placing, error } = useBetting();
+  const {
+    predictions,
+    placeParlay,
+    latestParlay,
+    bettingLoading: placing,
+    bettingError: error,
+  } = usePredictionMarket();
 
   // When the socket tells us a parlay has landed, clear and close
   useEffect(() => {

--- a/apps/client/src/components/dashboard/ParlayPanel.tsx
+++ b/apps/client/src/components/dashboard/ParlayPanel.tsx
@@ -1,12 +1,12 @@
 // apps/client/src/components/dashboard/ParlayPanel.tsx
 import { useState, useMemo } from 'react';
 import { useParlay } from '../../contexts/ParlayContext';
-import { usePredictions } from '../../hooks/usePredictions';
+import { usePredictionMarket } from '../../contexts/PredictionMarketContext';
 import ParlayModal from '../ParlayModal';
 
 export default function ParlayPanel() {
   const { state } = useParlay();
-  const { predictions } = usePredictions();
+  const { predictions } = usePredictionMarket();
   const [open, setOpen] = useState(false);
 
   /* ---------- Helpers ---------- */

--- a/apps/client/src/components/dashboard/PredictionPanel.tsx
+++ b/apps/client/src/components/dashboard/PredictionPanel.tsx
@@ -1,9 +1,10 @@
 // apps/client/src/components/dashboard/PredictionsPanel.tsx
-import { usePredictions } from '../../hooks/usePredictions';
+import { usePredictionMarket } from '../../contexts/PredictionMarketContext';
 import PredictionCard from '../PredictionCard'; // thin wrapper around your existing <li> markup
 
 export default function PredictionsPanel() {
-  const { predictions, loading, error } = usePredictions();
+  const { predictions, predictionsLoading: loading, predictionsError: error } =
+    usePredictionMarket();
 
   if (loading) return <p>Loading…</p>;
   if (error) return <p className="text-red-500">Error: {String(error)}</p>;

--- a/apps/client/src/contexts/PredictionMarketContext.tsx
+++ b/apps/client/src/contexts/PredictionMarketContext.tsx
@@ -1,0 +1,64 @@
+// apps/client/src/contexts/PredictionMarketContext.tsx
+import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+import { usePredictions } from '../hooks/usePredictions';
+import { useBetting } from '../hooks/useBetting';
+import type {
+  PredictionFull,
+  CreatePredictionPayload,
+} from '../api/predictions';
+import type { BetWithUser, PublicBet, PublicParlay } from '@ems/types';
+import type {
+  PlaceBetPayload,
+  PlaceParlayPayload,
+} from '../api/betting';
+
+interface PredictionMarketContextType {
+  predictions: PredictionFull[];
+  predictionsLoading: boolean;
+  predictionsError: Error | null;
+  refresh: () => Promise<void>;
+  createPrediction: (p: CreatePredictionPayload) => Promise<void>;
+  addOptimisticBet: (b: BetWithUser) => void;
+
+  placeBet: (p: PlaceBetPayload) => Promise<PublicBet>;
+  placeParlay: (p: PlaceParlayPayload) => Promise<PublicParlay>;
+  bettingLoading: boolean;
+  bettingError: Error | null;
+  latestBet: PublicBet | null;
+  latestParlay: PublicParlay | null;
+}
+
+const PredictionMarketContext = createContext<PredictionMarketContextType | undefined>(undefined);
+
+export function PredictionMarketProvider({ children }: { children: ReactNode }) {
+  const predictions = usePredictions();
+  const betting = useBetting();
+
+  const value: PredictionMarketContextType = {
+    predictions: predictions.predictions,
+    predictionsLoading: predictions.loading,
+    predictionsError: predictions.error,
+    refresh: predictions.refresh,
+    createPrediction: predictions.createPrediction,
+    addOptimisticBet: predictions.addOptimisticBet,
+    placeBet: betting.placeBet,
+    placeParlay: betting.placeParlay,
+    bettingLoading: betting.loading,
+    bettingError: betting.error,
+    latestBet: betting.latestBet,
+    latestParlay: betting.latestParlay,
+  };
+
+  return (
+    <PredictionMarketContext.Provider value={value}>
+      {children}
+    </PredictionMarketContext.Provider>
+  );
+}
+
+export function usePredictionMarket() {
+  const ctx = useContext(PredictionMarketContext);
+  if (!ctx) throw new Error('usePredictionMarket must be used within PredictionMarketProvider');
+  return ctx;
+}

--- a/apps/client/src/pages/Predictions.tsx
+++ b/apps/client/src/pages/Predictions.tsx
@@ -4,7 +4,7 @@ import type { PredictionFull } from '../api/predictions';
 import type { PublicPredictionOption, BetWithUser, ParlayLegWithUser } from '@ems/types';
 import BetForm from '../components/BetForm';
 import CreatePredictionForm from '../components/CreatePredictionForm';
-import { usePredictions } from '../hooks/usePredictions';
+import { usePredictionMarket } from '../contexts/PredictionMarketContext';
 import { useAuth } from '../contexts/AuthContext';
 import OddsBar from '../components/OddsBar';
 import BetsList from '../components/BetsList';
@@ -18,11 +18,11 @@ interface PredictionWithPools extends PredictionFull {
 export default function Predictions() {
   const {
     predictions: raw,
-    loading,
-    error,
+    predictionsLoading: loading,
+    predictionsError: error,
     createPrediction,
-    addOptimisticBet, // ← get from parent hook
-  } = usePredictions();
+    addOptimisticBet,
+  } = usePredictionMarket();
   const { user } = useAuth();
   const { dispatch } = useParlay();
 

--- a/apps/server/src/handlers/redisEventHandlers.ts
+++ b/apps/server/src/handlers/redisEventHandlers.ts
@@ -2,6 +2,7 @@
 import { Server } from 'socket.io';
 
 type RedisChannel =
+  | 'prediction:created'
   | 'prediction:resolved'
   | 'bet:placed'
   | 'parlay:placed'
@@ -21,6 +22,9 @@ export function registerRedisEventHandlers(io: Server, eventSub: any) {
     console.log(`[socket] Redis event: ${channel}`, payload);
 
     switch (channel) {
+      case 'prediction:created':
+        io.emit('predictionCreated', payload);
+        break;
       case 'prediction:resolved':
         io.emit('predictionResolved', payload);
         break;

--- a/apps/server/src/socket.ts
+++ b/apps/server/src/socket.ts
@@ -41,6 +41,7 @@ export async function initSocket(httpServer: HTTPServer) {
   // --- Redis event subscription/handler ---
   const eventSub = redisClient.duplicate();
   await eventSub.subscribe(
+    'prediction:created',
     'prediction:resolved',
     'bet:placed',
     'parlay:placed',


### PR DESCRIPTION
## Summary
- emit `prediction:created` events from Redis to clients
- subscribe to all prediction market channels in `socket.ts`
- introduce `PredictionMarketProvider` for shared prediction/betting state
- use new context across prediction and parlay components

## Testing
- `npm test` *(fails: Cannot find module '@ems/types')*
- `npm run lint` *(fails with multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879d8e083988320b9aeb20a0ae86c51