### PR TITLE
Improve betting popovers and add context info

### DIFF
--- a/apps/client/src/components/BetForm.tsx
+++ b/apps/client/src/components/BetForm.tsx
@@ -5,7 +5,7 @@
 // `betPlaced` broadcast to update the UI.
 // -----------------------------------------------------------------------------
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { usePredictionMarket } from '../contexts/PredictionContext';
 import { useAuth } from '../contexts/AuthContext';
 import type { PublicPredictionOption, BetWithUser } from '@ems/types';
@@ -21,12 +21,20 @@ export default function BetForm({ prediction, addOptimisticBet, onPlaced }: BetF
   const { user } = useAuth();
 
   const balance = user?.muskBucks ?? 0;
-  const [expanded, setExpanded] = useState(false);
+  const [open, setOpen] = useState(false);
   const [amount, setAmount] = useState(0);
   const [optionId, setOptionId] = useState(prediction.options[0]?.id ?? 0);
 
   const [placing, setPlacing] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    if (open) window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
 
   const submit = async () => {
     if (amount <= 0 || amount > balance || placing) return;
@@ -58,7 +66,7 @@ export default function BetForm({ prediction, addOptimisticBet, onPlaced }: BetF
         addOptimisticBet(optimistic);
       }
 
-      setExpanded(false);
+      setOpen(false);
       setAmount(0);
       onPlaced?.();
     } catch (e: any) {
@@ -72,9 +80,12 @@ export default function BetForm({ prediction, addOptimisticBet, onPlaced }: BetF
     return <p className="mt-2 text-sm text-tertiary italic">You have no MuskBucks to bet.</p>;
   }
 
-  if (expanded) {
+  if (open) {
     return (
-      <div className="mt-2 p-4 bg-surface border border-muted rounded-lg shadow-md space-y-4">
+      <div
+        className="fixed bottom-4 right-4 z-50 w-80 p-4 bg-surface border border-muted rounded-lg shadow-lg space-y-4"
+        onMouseLeave={() => setOpen(false)}
+      >
         <p className="text-sm">
           Balance: <span className="font-semibold">{balance} 🪙</span>
         </p>
@@ -113,7 +124,7 @@ export default function BetForm({ prediction, addOptimisticBet, onPlaced }: BetF
         <div className="flex justify-end space-x-3">
           <button
             type="button"
-            onClick={() => setExpanded(false)}
+            onClick={() => setOpen(false)}
             disabled={placing}
             className="px-4 py-2 bg-muted text-content rounded hover:bg-tertiary transition"
           >
@@ -134,7 +145,7 @@ export default function BetForm({ prediction, addOptimisticBet, onPlaced }: BetF
 
   return (
     <button
-      onClick={() => setExpanded(true)}
+      onClick={() => setOpen(true)}
       disabled={placing}
       className="px-4 py-2 bg-primary text-surface rounded-full font-semibold shadow transform hover:scale-105 transition disabled:opacity-50 w-full sm:w-auto"
     >

--- a/apps/client/src/components/ParlayModal.tsx
+++ b/apps/client/src/components/ParlayModal.tsx
@@ -58,13 +58,9 @@ export default function ParlayModal({ isOpen, onClose }: ParlayModalProps) {
   /* ---------- UI ---------- */
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40"
-      onClick={onClose}
+      className="fixed bottom-4 right-4 z-50 w-96 p-6 bg-surface text-content rounded-2xl shadow-xl space-y-4"
+      onMouseLeave={onClose}
     >
-      <div
-        className="bg-surface text-content rounded-2xl shadow-xl w-full max-w-md p-6 space-y-4"
-        onClick={(e) => e.stopPropagation()}
-      >
         <h2 className="text-lg font-medium">Your Parlay</h2>
 
         {/* Legs list */}
@@ -129,7 +125,6 @@ export default function ParlayModal({ isOpen, onClose }: ParlayModalProps) {
             {placing ? 'Placing…' : 'Place Parlay'}
           </button>
         </div>
-      </div>
     </div>
   );
 }

--- a/apps/server/src/repositories/BettingRepository.ts
+++ b/apps/server/src/repositories/BettingRepository.ts
@@ -1,16 +1,16 @@
 // apps/server/src/repositories/BettingRepository.ts
 import { PrismaClient } from '@prisma/client';
-import type { IBettingRepository } from './IBettingRepository';
+import type { IBettingRepository, OptionWithPrediction } from './IBettingRepository';
 import type { DbBet, DbParlay } from '@ems/types';
 
 const prisma = new PrismaClient();
 
 export class BettingRepository implements IBettingRepository {
-  findOptionWithPrediction(optionId: number) {
+  findOptionWithPrediction(optionId: number): Promise<OptionWithPrediction | null> {
     return prisma.predictionOption.findUnique({
       where: { id: optionId },
-      include: { prediction: { select: { id: true, resolved: true, expiresAt: true } } },
-    });
+      include: { prediction: { select: { id: true, title: true, resolved: true, expiresAt: true } } },
+    }) as any;
   }
 
   findUserById(userId: number) {

--- a/apps/server/src/repositories/IBettingRepository.ts
+++ b/apps/server/src/repositories/IBettingRepository.ts
@@ -5,13 +5,16 @@ import type { DbBet, DbParlay } from '@ems/types';
  * Betting data access contract: service validates inputs,
  * repository methods perform raw DB writes inside transactions.
  */
+export type OptionWithPrediction = {
+  id: number;
+  label: string;
+  odds: number;
+  predictionId: number;
+  prediction: { id: number; title: string; resolved: boolean; expiresAt: Date };
+};
+
 export interface IBettingRepository {
-  findOptionWithPrediction(optionId: number): Promise<
-    | (ReturnType<() => import('@prisma/client').PredictionOption> & {
-        prediction: { id: number; resolved: boolean; expiresAt: Date };
-      })
-    | null
-  >;
+  findOptionWithPrediction(optionId: number): Promise<OptionWithPrediction | null>;
   findUserById(
     userId: number,
   ): Promise<Pick<import('@prisma/client').User, 'id' | 'muskBucks' | 'name' | 'avatarUrl'> | null>;

--- a/apps/server/src/services/betting.service.ts
+++ b/apps/server/src/services/betting.service.ts
@@ -5,8 +5,8 @@
 // • No direct io.emit — real‑time fan‑out handled by redisEventHandlers.ts.
 // -----------------------------------------------------------------------------
 
-import type { IBettingRepository } from '../repositories/IBettingRepository';
-import type { DbBet, DbParlay, BetWithUser } from '@ems/types';
+import type { IBettingRepository, OptionWithPrediction } from '../repositories/IBettingRepository';
+import type { DbBet, DbParlay, BetWithUser, ParlayLegWithUser } from '@ems/types';
 import { BettingRepository } from '../repositories/BettingRepository';
 import redisClient from '../lib/redis';
 
@@ -50,6 +50,8 @@ export class BettingService {
         name: user.name,
         avatarUrl: user.avatarUrl,
       },
+      optionLabel: opt.label,
+      predictionTitle: opt.prediction.title,
     };
 
     // 6) Publish real‑time event (present‑tense channel)
@@ -70,7 +72,7 @@ export class BettingService {
     const detailed = await Promise.all(
       legs.map(({ optionId }) => this.repo.findOptionWithPrediction(optionId)),
     );
-    const validLegs = detailed.filter((opt): opt is NonNullable<typeof opt> => opt !== null);
+    const validLegs = detailed.filter((opt): opt is OptionWithPrediction => opt !== null);
     if (validLegs.length !== legs.length) throw new Error('OPTION_NOT_FOUND');
 
     // 2) Ensure none closed
@@ -100,8 +102,23 @@ export class BettingService {
       potentialPayout,
     );
 
-    // 6) Publish real‑time event (present‑tense channel)
-    await redisClient.publish('parlay:place', JSON.stringify(parlay));
+    // 6) Publish a leg event for each leg with extra info
+    const legsPayload: ParlayLegWithUser[] = validLegs.map((o) => ({
+      parlayId: parlay.id,
+      user: { id: user.id, name: user.name, avatarUrl: user.avatarUrl },
+      stake: amount,
+      optionId: o.id,
+      createdAt: parlay.createdAt,
+      predictionId: o.prediction.id,
+      optionLabel: o.label,
+      predictionTitle: o.prediction.title,
+    }));
+
+    await Promise.all(
+      legsPayload.map((leg) =>
+        redisClient.publish('parlay:place', JSON.stringify(leg)),
+      ),
+    );
 
     return parlay;
   }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -103,6 +103,9 @@ export interface BetWithUser extends PublicBet {
     name: string;
     avatarUrl: string | null;
   };
+  /** optional contextual info */
+  optionLabel?: string;
+  predictionTitle?: string;
 }
 
 // ——— Parlay & ParlayLeg ——————————————————————————————————————
@@ -117,6 +120,10 @@ export type ParlayLegWithUser = {
   stake: number;
   optionId: number;
   createdAt: string;
+  /** parent prediction id for context */
+  predictionId?: number;
+  optionLabel?: string;
+  predictionTitle?: string;
 };
 
 export type DbParlay     = PrismaParlay;


### PR DESCRIPTION
## Summary
- show additional bet and parlay leg info over sockets
- move BetForm UI to a floating popover
- update ParlayModal to be a small popover

## Testing
- `npm test` *(fails: Cannot find module '@ems/types' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687c549eed4c8320aa51f545f615f1d9