### PR TITLE
Add websocket-based activity ticker

### DIFF
--- a/apps/client/src/components/ActivityTicker.tsx
+++ b/apps/client/src/components/ActivityTicker.tsx
@@ -1,0 +1,38 @@
+import { useActivityTicker } from '../hooks/useActivityTicker';
+import { useMemo } from 'react';
+
+export default function ActivityTicker() {
+  const { items } = useActivityTicker(20);
+
+  const text = useMemo(() => {
+    return items
+      .map((a) => formatActivity(a))
+      .join('   •   ');
+  }, [items]);
+
+  if (!items.length) return null;
+
+  return (
+    <div className="bg-blue-600 text-white overflow-hidden whitespace-nowrap text-sm">
+      <div className="animate-marquee px-4 py-1">{text}</div>
+    </div>
+  );
+}
+
+function formatActivity(a: { type: string; details?: any }) {
+  const d = a.details && typeof a.details === 'object' ? a.details : {};
+  switch (a.type) {
+    case 'BET_PLACED':
+      return `Bet placed on #${d.predictionId ?? ''}`.trim();
+    case 'PARLAY_PLACED':
+      return `Parlay started #${d.parlayId ?? ''}`.trim();
+    case 'POST_CREATED':
+      return 'New profile post';
+    case 'COMMENT_CREATED':
+      return 'New comment';
+    case 'PREDICTION_CREATED':
+      return `Prediction: ${d.title ?? ''}`.trim();
+    default:
+      return a.type;
+  }
+}

--- a/apps/client/src/components/MainLayout.tsx
+++ b/apps/client/src/components/MainLayout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import NavBar from './NavBar';
 import ChatBar from './ChatBar';
+import ActivityTicker from './ActivityTicker';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -14,6 +15,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
   return (
     <div className="flex flex-col min-h-screen bg-background text-content transition-colors duration-300">
       <NavBar />
+      <ActivityTicker />
 
       {/* Main content is below NavBar, but above fixed ChatBar */}
       <div className="relative flex-1">

--- a/apps/client/src/hooks/useActivityTicker.ts
+++ b/apps/client/src/hooks/useActivityTicker.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import type { UserActivity } from '@ems/types';
+import { useSocket } from '../contexts/SocketContext';
+
+export function useActivityTicker(limit = 20) {
+  const socket = useSocket();
+  const [items, setItems] = useState<UserActivity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const requestTicker = () => socket.emit('activity:ticker', limit);
+    const handleTicker = (data: UserActivity[]) => {
+      setItems(data);
+      setLoading(false);
+    };
+
+    socket.on('connect', requestTicker);
+    requestTicker();
+    socket.on('activity:ticker', handleTicker);
+
+    return () => {
+      socket.off('connect', requestTicker);
+      socket.off('activity:ticker', handleTicker);
+    };
+  }, [socket, limit]);
+
+  useEffect(() => {
+    const handleNewsflash = (item: UserActivity) => {
+      setItems((prev) => [item, ...prev].slice(0, limit));
+    };
+    socket.on('activityNewsflash', handleNewsflash);
+    return () => {
+      socket.off('activityNewsflash', handleNewsflash);
+    };
+  }, [socket, limit]);
+
+  return { items, loading, error };
+}

--- a/apps/client/tailwind.config.js
+++ b/apps/client/tailwind.config.js
@@ -15,6 +15,15 @@ module.exports = {
         content: 'var(--color-content)',
         background: 'var(--color-background)',
       },
+      keyframes: {
+        marquee: {
+          from: { transform: 'translateX(100%)' },
+          to: { transform: 'translateX(-100%)' },
+        },
+      },
+      animation: {
+        marquee: 'marquee 20s linear infinite',
+      },
     },
   },
   plugins: [],

--- a/apps/server/src/handlers/activityTickerHandlers.ts
+++ b/apps/server/src/handlers/activityTickerHandlers.ts
@@ -1,0 +1,17 @@
+import { Socket } from 'socket.io';
+import { activityTickerService } from '../services/activityTicker.service';
+import type { UserActivity } from '@ems/types';
+
+export function registerActivityTickerHandlers(socket: Socket) {
+  socket.on('activity:ticker', async (limit?: number) => {
+    try {
+      const items: UserActivity[] = await activityTickerService.getTicker(
+        typeof limit === 'number' ? limit : 20,
+      );
+      socket.emit('activity:ticker', items);
+    } catch (err) {
+      console.error('[activity] ticker fetch failed:', err);
+      socket.emit('activity:ticker', []);
+    }
+  });
+}

--- a/apps/server/src/services/activityTicker.service.ts
+++ b/apps/server/src/services/activityTicker.service.ts
@@ -1,0 +1,15 @@
+import redisClient from '../lib/redis';
+import type { UserActivity } from '@ems/types';
+
+export class ActivityTickerService {
+  private readonly TICKER_LIST = 'activity:ticker';
+
+  constructor(private redis = redisClient) {}
+
+  async getTicker(limit = 20): Promise<UserActivity[]> {
+    const items = await this.redis.lrange(this.TICKER_LIST, 0, limit - 1);
+    return items.map((i) => JSON.parse(i) as UserActivity);
+  }
+}
+
+export const activityTickerService = new ActivityTickerService();

--- a/apps/server/src/socket.ts
+++ b/apps/server/src/socket.ts
@@ -12,6 +12,7 @@ import redisClient from './lib/redis';
 import { socketAuthMiddleware } from './middleware/socketAuthMiddleware';
 import { registerChatHandlers } from './handlers/chatHandlers';
 import { registerBetHandlers } from './handlers/betSocketHandlers';
+import { registerActivityTickerHandlers } from './handlers/activityTickerHandlers';
 import { registerRedisEventHandlers } from './handlers/redisEventHandlers';
 import { registerRedisChatHandlers } from './handlers/redisChatEventHandlers';
 // import { registerRoomHandlers } from './handlers/roomHandlers'; // future rooms
@@ -67,6 +68,7 @@ export async function initSocket(httpServer: HTTPServer) {
       // registerRoomHandlers(io, socket); // Uncomment when multi‑room is live
       registerChatHandlers(socket);
       registerBetHandlers(socket);
+      registerActivityTickerHandlers(socket);
     } catch (err) {
       console.error('[socket] handler error:', err);
     }


### PR DESCRIPTION
## Summary
- switch activity ticker hook to request data over websockets
- drop unused REST controller and route
- add `registerActivityTickerHandlers` to serve ticker via socket
- wire up server socket to use new handlers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_687d7f828e548320835d95b91f118515