### PR TITLE
Add client frontend TypeScript and React 19 review

### DIFF
--- a/docs/client-review.md
+++ b/docs/client-review.md
@@ -1,0 +1,52 @@
+# Client Frontend Review: TypeScript Rigor & React 19 Readiness
+
+## 1. Executive Summary
+- The `apps/client` refactor introduced modern concurrency primitives such as `useOptimistic`, yet the codebase still leans heavily on `any` casts and untyped payloads that undermine TypeScript's safety guarantees. 【F:apps/client/src/contexts/PredictionContext.tsx†L60-L137】【F:apps/client/src/types/events.ts†L56-L168】
+- React 19-friendly hooks are present, but critical flows (initial data loads, forms, event subscriptions) continue to rely on legacy `useEffect`/state patterns that limit Suspense adoption and concurrent rendering benefits. 【F:apps/client/src/contexts/AuthContext.tsx†L95-L159】【F:apps/client/src/hooks/useOptimisticUpdate.ts†L67-L197】
+- The provider stack remains monolithic, increasing render cost and complicating gradual upgrades to features like partial re-rendering and transition tracing. 【F:apps/client/src/App.tsx†L4-L58】
+
+## 2. TypeScript Evaluation
+### Strengths
+- Contexts expose typed APIs (`PredictionView`, `BetWithUser`, etc.) and most providers guard usage with custom hooks that throw outside their scope, preventing silent runtime failures. 【F:apps/client/src/contexts/PredictionContext.tsx†L43-L118】【F:apps/client/src/contexts/PredictionContext.tsx†L498-L503】
+- Shared event infrastructure centralizes Redis channel contracts, laying groundwork for a discriminated union-style event map once payloads are finalized. 【F:apps/client/src/types/events.ts†L7-L175】
+
+### Gaps & Risks
+- Widespread `any` leakage across contexts, hooks, and components nullifies strict mode—optimistic reducer payloads, activity feed transformers, and socket listeners all bypass typing. 【F:apps/client/src/contexts/PredictionContext.tsx†L76-L137】【F:apps/client/src/contexts/ActivityContext.tsx†L155-L256】【F:apps/client/src/contexts/EventBusCoreContext.tsx†L76-L168】
+- `EventPayloadMap` defaults to `any` for numerous channels, so downstream consumers lose compile-time coverage (e.g., chat typing, unified activity). 【F:apps/client/src/types/events.ts†L108-L168】
+- `useOptimisticUpdate` re-exposes `subscribe(successEvent, (payload: any) => …)` and tracks `optimisticValue` in effect dependencies, forcing resubscription and risking stale closures; the hook also conflates `string` events with `RedisChannel` typings. 【F:apps/client/src/hooks/useOptimisticUpdate.ts†L45-L198】
+- Forms and domain models often store server data as `Record<string, any>` instead of richer discriminated unions, complicating analytics features like prediction timelines. 【F:apps/client/src/components/prediction/PredictionStats.tsx†L55-L202】
+
+## 3. React 19 Patterns Assessment
+### What’s Working
+- Key domains (auth, predictions, reactions) already adopt `useOptimistic` and `startTransition` to separate urgent vs. background work. 【F:apps/client/src/contexts/AuthContext.tsx†L54-L88】【F:apps/client/src/contexts/EventBusCoreContext.tsx†L136-L168】
+- Event Bus hydration guards demonstrate awareness of concurrent hydration pitfalls by deferring socket payloads until the app is ready. 【F:apps/client/src/contexts/EventBusCoreContext.tsx†L110-L188】
+
+### Upgrade Gaps
+- Data fetching still happens via imperative `useEffect` calls with manual loading state rather than Suspense resources or router loaders, preventing streaming and `use` adoption. 【F:apps/client/src/contexts/AuthContext.tsx†L95-L159】【F:apps/client/src/contexts/PredictionContext.tsx†L148-L207】
+- Forms (e.g., login) manage submission state manually and rely on `window.location` redirects instead of `useActionState`/`useFormStatus`, reducing compatibility with the new form actions model. 【F:apps/client/src/pages/Login.tsx†L6-L73】
+- Provider nesting in `App` couples unrelated concerns (activity, predictions, chat, achievements) in a single React tree, impeding selective suspense boundaries and transition profiling. 【F:apps/client/src/App.tsx†L4-L58】
+- Custom hooks subscribe to EventBus channels inside `useEffect` without `useEffectEvent` or dedicated transition scheduling, so handlers capture stale state and cannot opt into the new transition tracing APIs. 【F:apps/client/src/hooks/useOptimisticUpdate.ts†L67-L198】【F:apps/client/src/contexts/ActivityContext.tsx†L155-L256】
+
+## 4. Modernization Plan
+### Phase 1 – Restore Type Safety (Short Term)
+1. Replace ad-hoc `any` payloads with discriminated payload types; extend `EventPayloadMap` to cover chat/activity and remove the `[key: string]: any` escape hatch. 【F:apps/client/src/types/events.ts†L108-L168】
+2. Refine optimistic reducer actions so each variant carries a typed payload (e.g., `PlaceBetAction`, `PlaceParlayAction`) and eliminate `(leg: any)` casts in `PredictionContext`. 【F:apps/client/src/contexts/PredictionContext.tsx†L76-L137】
+3. Introduce typed helpers for activity feed normalization instead of `Activity` creation from `any[]`, and surface validation failures early. 【F:apps/client/src/contexts/ActivityContext.tsx†L155-L256】
+4. Harden shared utilities like `useOptimisticUpdate` by parameterizing `successEvent`/`failureEvent` over `RedisChannel` unions and moving subscription callbacks into `useEffectEvent` (or memoized stable functions) to avoid resubscription loops. 【F:apps/client/src/hooks/useOptimisticUpdate.ts†L67-L198】
+
+### Phase 2 – React 19 Data & Form Patterns (Mid Term)
+1. Migrate auth and prediction bootstrapping to router loaders or Suspense-friendly resource hooks so initial data can leverage `use` and streaming boundaries. 【F:apps/client/src/contexts/AuthContext.tsx†L95-L159】【F:apps/client/src/contexts/PredictionContext.tsx†L148-L207】
+2. Introduce Suspense boundaries around major routes (timeline, predictions) and convert loading placeholders to `<Suspense fallback>` components instead of manual `loading` booleans. 【F:apps/client/src/pages/Predictions.tsx†L20-L64】【F:apps/client/src/components/prediction/PredictionFeed.tsx†L1-L40】
+3. Refactor form pages to use `useActionState`/`useFormStatus` for submission state and navigation rather than imperative redirects. 【F:apps/client/src/pages/Login.tsx†L6-L73】
+4. Adopt `useEffectEvent` for EventBus-driven updates to keep listeners stable and align with React 19’s event semantics. 【F:apps/client/src/contexts/ActivityContext.tsx†L155-L256】
+
+### Phase 3 – Architectural Cleanup (Long Term)
+1. Split the provider tree into route-scoped layouts (e.g., predictions shell, social shell) to limit re-render breadth and support future partial hydration. 【F:apps/client/src/App.tsx†L4-L58】
+2. Layer analytics and debugging providers (EventBus metrics, leak detection) behind feature flags or lazy imports to reduce baseline bundle size. 【F:apps/client/src/components/debug/EventMetricsDashboard.tsx†L1-L200】【F:apps/client/src/components/debug/LeakDetectionPanel.tsx†L1-L220】
+3. Normalize data transformation utilities (`PredictionStats`, leaderboard transformers) using `satisfies` clauses and branded types to guarantee shape compatibility during refactors. 【F:apps/client/src/components/prediction/PredictionStats.tsx†L55-L202】【F:apps/client/src/components/leaderboard/dataTransformers.ts†L274-L330】
+4. Expand automated tests around the event system (hook/unit level) to validate optimistic flows once type guards are enforced. 【F:apps/client/src/tests/leakDetection.test.tsx†L1-L400】
+
+## 5. Immediate Next Steps
+- Run a focused lint pass that forbids implicit `any` in the client workspace and track remediation progress per module.
+- Prototype a Suspense-enabled prediction feed (loader + fallback) to validate router/data strategy before scaling to other routes.
+- Schedule cross-team alignment on shared payload schemas so server and client converge on strict typings without `as any` shims.


### PR DESCRIPTION
## Summary
- add a comprehensive review of the client TypeScript safety and React 19 readiness
- document strengths, gaps, and a phased modernization plan for the client application

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de26d91e4083208cc928007c7f54b6